### PR TITLE
Add AGENTS guide and extend setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Guidelines
+
+This repository uses `uv` for dependency management and `pytest` for testing.
+
+## Required Steps for Contributions
+
+1. Run `scripts/setup.sh` to create and activate the virtual environment. This will install all project and development dependencies.
+2. After making changes, ensure tests pass with:
+   ```bash
+   pytest -q
+   ```
+3. Update documentation when relevant.
+
+Pull request messages should include **Summary** and **Testing** sections describing code changes and test results.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,6 +35,10 @@ uv pip install -e .
 echo "📥 Installing development dependencies..."
 uv pip install -e ".[dev]"
 
+# Install additional modules required for tests
+echo "📥 Installing extra modules for testing..."
+uv pip install fastapi anyio
+
 # Verify installation
 echo "🔍 Verifying installation..."
 python -c "import src.server.databricks_mcp_server; print('✅ MCP server module imported successfully')"


### PR DESCRIPTION
## Summary
- document contributor workflow in new `AGENTS.md`
- update `scripts/setup.sh` to install FastAPI and AnyIO for the tests

## Testing
- `bash scripts/setup.sh`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68419b66dfc8832f9e2b8711cb1904c5