### PR TITLE
feat(sql): bump execute_sql wait_timeout to 50s, expose get_statement_status + cancel_statement

### DIFF
--- a/databricks_mcp/api/sql.py
+++ b/databricks_mcp/api/sql.py
@@ -20,41 +20,44 @@ async def execute_statement(
     parameters: Optional[Dict[str, Any]] = None,
     row_limit: int = 10000,
     byte_limit: int = 100000000,  # 100MB
+    wait_timeout: str = "50s",
 ) -> Dict[str, Any]:
     """
     Execute a SQL statement.
-    
+
     Args:
         statement: The SQL statement to execute
-        warehouse_id: ID of the SQL warehouse to use (optional if DATABRICKS_WAREHOUSE_ID is set) (optional if DATABRICKS_WAREHOUSE_ID is set)
+        warehouse_id: ID of the SQL warehouse to use (optional if DATABRICKS_WAREHOUSE_ID is set)
         catalog: Optional catalog to use
         schema: Optional schema to use
         parameters: Optional statement parameters
         row_limit: Maximum number of rows to return
         byte_limit: Maximum number of bytes to return
-        
+        wait_timeout: How long the Statement Execution API waits synchronously before
+            returning a PENDING handle. "0s" returns immediately; the API caps at "50s".
+
     Returns:
         Response containing query results
-        
+
     Raises:
         DatabricksAPIError: If the API request fails
         ValueError: If no warehouse_id is provided and DATABRICKS_WAREHOUSE_ID is not set
     """
     logger.info(f"Executing SQL statement: {statement[:100]}...")
-    
+
     # Use provided warehouse_id or fall back to environment variable
     effective_warehouse_id = warehouse_id or settings.DATABRICKS_WAREHOUSE_ID
-    
+
     if not effective_warehouse_id:
         raise ValueError(
             "warehouse_id must be provided either as parameter or "
             "set DATABRICKS_WAREHOUSE_ID environment variable"
         )
-    
+
     request_data = {
         "statement": statement,
         "warehouse_id": effective_warehouse_id,
-        "wait_timeout": "10s",
+        "wait_timeout": wait_timeout,
         "format": "JSON_ARRAY",
         "disposition": "INLINE",
         "row_limit": row_limit,

--- a/databricks_mcp/server/databricks_mcp_server.py
+++ b/databricks_mcp/server/databricks_mcp_server.py
@@ -592,12 +592,21 @@ class DatabricksMCPServer(FastMCP):
             )
 
         # SQL tools
-        @self.tool(name="execute_sql", description="Execute a SQL statement")
+        @self.tool(
+            name="execute_sql",
+            description=(
+                "Execute a SQL statement. Waits up to wait_timeout (default 50s, the "
+                "Statement Execution API maximum) for synchronous completion; if the "
+                "query is still running when the timeout expires the response carries "
+                "status=PENDING and a statement_id you can pass to get_statement_status."
+            ),
+        )
         async def execute_sql(
             statement: str,
             warehouse_id: Optional[str] = None,
             catalog: Optional[str] = None,
             schema_name: Optional[str] = None,
+            wait_timeout: str = "50s",
             ctx: Context | None = None,
         ) -> CallToolResult:
             async def action() -> Any:
@@ -607,6 +616,7 @@ class DatabricksMCPServer(FastMCP):
                     warehouse_id=warehouse_id,
                     catalog=catalog,
                     schema=schema_name,
+                    wait_timeout=wait_timeout,
                 )
                 await self._report_progress(ctx, 70, message="SQL statement completed")
                 return result
@@ -615,6 +625,43 @@ class DatabricksMCPServer(FastMCP):
                 "execute_sql",
                 action,
                 lambda data: f"SQL statement {data.get('statement_id', 'completed')} executed",
+                ctx,
+            )
+
+        @self.tool(
+            name="get_statement_status",
+            description=(
+                "Fetch the current status and (if available) result of a previously "
+                "submitted SQL statement by its statement_id. Use this to poll a "
+                "statement that execute_sql left in PENDING state."
+            ),
+        )
+        async def get_statement_status(
+            statement_id: str,
+            ctx: Context | None = None,
+        ) -> CallToolResult:
+            return await self._run_tool(
+                "get_statement_status",
+                lambda: sql.get_statement_status(statement_id),
+                lambda data: (
+                    f"Statement {statement_id} status: "
+                    f"{data.get('status', {}).get('state', 'UNKNOWN')}"
+                ),
+                ctx,
+            )
+
+        @self.tool(
+            name="cancel_statement",
+            description="Cancel a running SQL statement by its statement_id.",
+        )
+        async def cancel_statement(
+            statement_id: str,
+            ctx: Context | None = None,
+        ) -> CallToolResult:
+            return await self._run_tool(
+                "cancel_statement",
+                lambda: sql.cancel_statement(statement_id),
+                lambda _: f"Cancellation requested for statement {statement_id}",
                 ctx,
             )
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,75 @@
+"""
+Tests for the SQL API and the corresponding MCP tools.
+"""
+
+import importlib.util
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+if importlib.util.find_spec("mcp") is None:  # pragma: no cover - environment guard
+    pytest.skip("mcp package not available", allow_module_level=True)
+
+from databricks_mcp.api import sql
+from databricks_mcp.server.databricks_mcp_server import DatabricksMCPServer
+
+
+@pytest.mark.asyncio
+async def test_execute_statement_defaults_to_50s_wait_timeout():
+    """The bumped synchronous wait window catches most queries inline."""
+    with patch("databricks_mcp.api.sql.make_api_request", new=AsyncMock(return_value={})) as mock:
+        await sql.execute_statement(statement="SELECT 1", warehouse_id="wh-1")
+
+    body = mock.call_args.kwargs["data"]
+    assert body["wait_timeout"] == "50s"
+    assert body["statement"] == "SELECT 1"
+    assert body["warehouse_id"] == "wh-1"
+
+
+@pytest.mark.asyncio
+async def test_execute_statement_honors_explicit_wait_timeout():
+    """Callers can override the wait window (e.g. '0s' for fire-and-poll flows)."""
+    with patch("databricks_mcp.api.sql.make_api_request", new=AsyncMock(return_value={})) as mock:
+        await sql.execute_statement(
+            statement="SELECT 1",
+            warehouse_id="wh-1",
+            wait_timeout="0s",
+        )
+
+    assert mock.call_args.kwargs["data"]["wait_timeout"] == "0s"
+
+
+@pytest.mark.asyncio
+async def test_get_statement_status_calls_correct_endpoint():
+    with patch("databricks_mcp.api.sql.make_api_request", new=AsyncMock(return_value={})) as mock:
+        await sql.get_statement_status("01abc")
+
+    method, path = mock.call_args.args[0], mock.call_args.args[1]
+    assert method == "GET"
+    assert path == "/api/2.0/sql/statements/01abc"
+
+
+@pytest.mark.asyncio
+async def test_cancel_statement_calls_correct_endpoint():
+    with patch("databricks_mcp.api.sql.make_api_request", new=AsyncMock(return_value={})) as mock:
+        await sql.cancel_statement("01abc")
+
+    method, path = mock.call_args.args[0], mock.call_args.args[1]
+    assert method == "POST"
+    assert path == "/api/2.0/sql/statements/01abc/cancel"
+
+
+@pytest.mark.asyncio
+async def test_new_sql_tools_are_registered():
+    """execute_sql gained a wait_timeout arg; polling/cancel tools are exposed."""
+    server = DatabricksMCPServer()
+    tools = {tool.name: tool for tool in await server.list_tools()}
+
+    assert "execute_sql" in tools
+    assert "wait_timeout" in tools["execute_sql"].inputSchema["properties"]
+
+    assert "get_statement_status" in tools
+    assert "statement_id" in tools["get_statement_status"].inputSchema["properties"]
+
+    assert "cancel_statement" in tools
+    assert "statement_id" in tools["cancel_statement"].inputSchema["properties"]


### PR DESCRIPTION
## Summary

The `execute_sql` MCP tool currently submits statements with `wait_timeout=10s` (the Databricks Statement Execution API default) and there is no companion MCP tool to fetch the result of a statement the API returned in `PENDING` state. Long-running or cold-warehouse queries become unreachable from the chat/agent session — recovery requires either the Databricks UI query history or a raw curl against `/api/2.0/sql/statements/{id}`.

This PR fixes both problems with minimal surface change.

## Changes

- `sql.execute_statement`: new `wait_timeout` parameter, default `"50s"` — the maximum synchronous wait supported by the Statement Execution API. Catches the vast majority of queries inline.
- `execute_sql` MCP tool: forwards the new `wait_timeout` arg so callers can override (e.g. `"0s"` for fire-and-poll flows).
- New `get_statement_status` MCP tool: thin wrapper over the existing `sql.get_statement_status` helper so agents can poll a PENDING statement to completion.
- New `cancel_statement` MCP tool: wraps the existing `sql.cancel_statement` helper for symmetry — lets agents free warehouse capacity when they abandon a query.

## Tests

New `tests/test_sql.py` covers:

- `execute_statement` defaults to `wait_timeout="50s"` and forwards explicit overrides.
- `get_statement_status` / `cancel_statement` call the correct endpoints.
- The three tools (`execute_sql` with `wait_timeout` in its input schema, `get_statement_status`, `cancel_statement`) are registered in the server's tool list.

\`\`\`
tests/test_sql.py::test_execute_statement_defaults_to_50s_wait_timeout PASSED
tests/test_sql.py::test_execute_statement_honors_explicit_wait_timeout PASSED
tests/test_sql.py::test_get_statement_status_calls_correct_endpoint PASSED
tests/test_sql.py::test_cancel_statement_calls_correct_endpoint PASSED
tests/test_sql.py::test_new_sql_tools_are_registered PASSED
\`\`\`

The five pre-existing failures on \`master\` (\`test_server_structured\`, \`test_transcript\`, \`test_tool_metadata::test_list_tools_has_schemas\`) are caused by API drift in the \`mcp\` SDK (\`ToolManager.call_tool\` no longer accepts \`convert_result\`; \`Tool\` no longer has \`outputSchema\`) and are unrelated to this PR.

## Backwards compatibility

- The `wait_timeout` parameter is optional with a default. Existing callers see no breakage in the API surface — only a longer (≤50s vs ≤10s) synchronous wait window, which is strictly better for usability and matches the Statement Execution API's documented maximum.
- No tools are removed or renamed.